### PR TITLE
Allow usage of "*" to signify run command on all online subservers

### DIFF
--- a/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
+++ b/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
@@ -110,7 +110,7 @@ public final class SubCommand extends Command implements TabExecutor {
                 } else if (args[0].equalsIgnoreCase("cmd") || args[0].equalsIgnoreCase("command")) {
                     if (args.length > 2) {
                         Map<String, Server> servers = plugin.api.getServers();
-                        if (!servers.keySet().contains(args[1].toLowerCase())) {
+                        if (!(servers.keySet().contains(args[1].toLowerCase()) || args[1].equals("*"))) {
                             sender.sendMessage("SubServers > There is no server with that name");
                         } else if (!(servers.get(args[1].toLowerCase()) instanceof SubServer)) {
                             sender.sendMessage("SubServers > That Server is not a SubServer");
@@ -125,7 +125,15 @@ public final class SubCommand extends Command implements TabExecutor {
                                     str = str + " " + args[i];
                                 } while ((i + 1) != args.length);
                             }
-                            ((SubServer) servers.get(args[1].toLowerCase())).command(str);
+                            if (args[1].equals("*")) {
+                                for (Server server : servers.values()) {
+                                    if (((SubServer) server).isRunning()) {
+                                        ((SubServer) server).command(str);
+                                    }
+                                }
+                            } else {
+                                ((SubServer) servers.get(args[1].toLowerCase())).command(str);
+                            }
                         }
                     } else {
                         sender.sendMessage("SubServers > Usage: " + label + " " + args[0].toLowerCase() + " <SubServer> <Command> [Args...]");

--- a/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
+++ b/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
@@ -118,10 +118,8 @@ public final class SubCommand extends Command implements TabExecutor {
                             sender.sendMessage("SubServers > That SubServer is not running");
                         } else {
                             String str = args[2];
-                            if (args.length > 3) {
-                                for (int i = 3; i < args.length; i++) {
-                                    str += " " + args[i];
-                                }
+                            for (int i = 3; i < args.length; i++) {
+                                str += " " + args[i];
                             }
                             if (args[1].equals("*")) {
                                 for (Server server : servers.values()) {

--- a/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
+++ b/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubCommand.java
@@ -117,13 +117,11 @@ public final class SubCommand extends Command implements TabExecutor {
                         } else if (!((SubServer) servers.get(args[1].toLowerCase())).isRunning()) {
                             sender.sendMessage("SubServers > That SubServer is not running");
                         } else {
-                            int i = 2;
                             String str = args[2];
                             if (args.length > 3) {
-                                do {
-                                    i++;
-                                    str = str + " " + args[i];
-                                } while ((i + 1) != args.length);
+                                for (int i = 3; i < args.length; i++) {
+                                    str += " " + args[i];
+                                }
                             }
                             if (args[1].equals("*")) {
                                 for (Server server : servers.values()) {


### PR DESCRIPTION
This would allow the usage of "*" to signify run the command on all online subservers. For example,"sub cmd * say hello world!" would run "say hello world! on all online subservers. This will remove the need for sub server networks to run additional plugins that allow running commands across all servers.