### PR TITLE
Making host reconnect delay configurable

### DIFF
--- a/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
+++ b/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
@@ -375,6 +375,7 @@ public final class SubDataClient {
             if (!socket.isClosed()) socket.close();
             host.api.executeEvent(new SubNetworkDisconnectEvent());
             log.info.println("The SubData Connection was closed");
+            int reconnectDelay = host.config.get().getSection("Settings").getSection("SubData").getInt("Reconnect delay");
             if (reconnect) {
                 log.info.println("Attempting to reconnect in 30 seconds");
                 Timer timer = new Timer();
@@ -392,7 +393,7 @@ public final class SubDataClient {
                             log.warn.println("Connection was unsuccessful, retrying in 30 seconds");
                         }
                     }
-                }, TimeUnit.SECONDS.toMillis(30), TimeUnit.SECONDS.toMillis(30));
+                }, TimeUnit.SECONDS.toMillis(reconnectDelay), TimeUnit.SECONDS.toMillis(reconnectDelay));
             }
             host.subdata = null;
         }

--- a/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
+++ b/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
@@ -377,7 +377,7 @@ public final class SubDataClient {
             log.info.println("The SubData Connection was closed");
             int reconnectDelay = host.config.get().getSection("Settings").getSection("SubData").getInt("Reconnect delay", 30);
             if (reconnect) {
-                log.info.println("Attempting to reconnect in 30 seconds");
+                log.info.println("Attempting to reconnect in " + reconnectDelay + " seconds");
                 Timer timer = new Timer();
                 timer.scheduleAtFixedRate(new TimerTask() {
                     @Override
@@ -390,7 +390,7 @@ public final class SubDataClient {
                                 queue.remove(0);
                             }
                         } catch (IOException e) {
-                            log.warn.println("Connection was unsuccessful, retrying in 30 seconds");
+                            log.warn.println("Connection was unsuccessful, retrying in " + reconnectDelay + " seconds");
                         }
                     }
                 }, TimeUnit.SECONDS.toMillis(reconnectDelay), TimeUnit.SECONDS.toMillis(reconnectDelay));

--- a/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
+++ b/SubServers.Host/src/net/ME1312/SubServers/Host/Network/SubDataClient.java
@@ -375,7 +375,7 @@ public final class SubDataClient {
             if (!socket.isClosed()) socket.close();
             host.api.executeEvent(new SubNetworkDisconnectEvent());
             log.info.println("The SubData Connection was closed");
-            int reconnectDelay = host.config.get().getSection("Settings").getSection("SubData").getInt("Reconnect delay");
+            int reconnectDelay = host.config.get().getSection("Settings").getSection("SubData").getInt("Reconnect delay", 30);
             if (reconnect) {
                 log.info.println("Attempting to reconnect in 30 seconds");
                 Timer timer = new Timer();


### PR DESCRIPTION
This PR makes the reconnect delay of hosts configurable. This can be useful if the host contains subservers that the network requires immediately after starting the network.