### PR TITLE
Do not generate default templates if the templates folder already exists

### DIFF
--- a/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubPlugin.java
+++ b/SubServers.Bungee/src/net/ME1312/SubServers/Bungee/SubPlugin.java
@@ -88,30 +88,32 @@ public final class SubPlugin extends BungeeCord {
         }
         lang = new YAMLConfig(new UniversalFile(dir, "lang.yml"));
 
-        if (!(new UniversalFile(dir, "Templates").exists())) new UniversalFile(dir, "Templates").mkdirs();
-        if (!(new UniversalFile(dir, "Templates:Vanilla:template.yml").exists())) {
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/vanilla.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Created ~/SubServers/Templates/Vanilla");
-        } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Vanilla:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.12b+"))) != 0) {
-            Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Vanilla.old" + Math.round(Math.random() * 100000)).toPath());
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/vanilla.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Updated ~/SubServers/Templates/Vanilla");
-        }
-        if (!(new UniversalFile(dir, "Templates:Spigot:template.yml").exists())) {
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/spigot.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Created ~/SubServers/Templates/Spigot");
-        } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Spigot:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.11.2m+"))) != 0) {
-            Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Spigot.old" + Math.round(Math.random() * 100000)).toPath());
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/spigot.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Updated ~/SubServers/Templates/Spigot");
-        }
-        if (!(new UniversalFile(dir, "Templates:Sponge:template.yml").exists())) {
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/sponge.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Created ~/SubServers/Templates/Sponge");
-        } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Sponge:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.11.2m+"))) != 0) {
-            Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Sponge.old" + Math.round(Math.random() * 100000)).toPath());
-            Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/sponge.zip"), new UniversalFile(dir, "Templates"));
-            System.out.println("SubServers > Updated ~/SubServers/Templates/Sponge");
+        if (!(new UniversalFile(dir, "Templates").exists())) {
+            new UniversalFile(dir, "Templates").mkdirs();
+            if (!(new UniversalFile(dir, "Templates:Vanilla:template.yml").exists())) {
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/vanilla.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Created ~/SubServers/Templates/Vanilla");
+            } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Vanilla:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.12b+"))) != 0) {
+                Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Vanilla.old" + Math.round(Math.random() * 100000)).toPath());
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/vanilla.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Updated ~/SubServers/Templates/Vanilla");
+            }
+            if (!(new UniversalFile(dir, "Templates:Spigot:template.yml").exists())) {
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/spigot.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Created ~/SubServers/Templates/Spigot");
+            } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Spigot:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.11.2m+"))) != 0) {
+                Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Spigot.old" + Math.round(Math.random() * 100000)).toPath());
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/spigot.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Updated ~/SubServers/Templates/Spigot");
+            }
+            if (!(new UniversalFile(dir, "Templates:Sponge:template.yml").exists())) {
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/sponge.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Created ~/SubServers/Templates/Sponge");
+            } else if ((new Version((new YAMLConfig(new UniversalFile(dir, "Templates:Sponge:template.yml"))).get().getString("Version", "0")).compareTo(new Version("2.11.2m+"))) != 0) {
+                Files.move(new UniversalFile(dir, "Templates:Vanilla").toPath(), new UniversalFile(dir, "Templates:Sponge.old" + Math.round(Math.random() * 100000)).toPath());
+                Util.unzip(SubPlugin.class.getResourceAsStream("/net/ME1312/SubServers/Bungee/Library/Files/Templates/sponge.zip"), new UniversalFile(dir, "Templates"));
+                System.out.println("SubServers > Updated ~/SubServers/Templates/Sponge");
+            }
         }
 
         if (new UniversalFile(dir, "Recently Deleted").exists()) {


### PR DESCRIPTION
This allows for the user to actually delete unused templates that only create more data to transfer to hosts.